### PR TITLE
docs: expand on usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,42 @@
 # terraform-provider-uptimerobot
+
 Apache 2 licensed Uptimerobot Terraform Provider
+
+## Installation
+
+```bash
+git clone git@github.com:SpamapS/terraform-provider-uptimerobot.git
+cd terraform-provider-uptimerobot
+go build
+mv terraform-provider-uptimerobot $HOME/.terraform.d/plugins
+```
+
+## Usage
+
+Add the uptimerobot provider:
+
+```hcl
+provider "uptimerobot" {}
+```
+
+Set the `UPTIMEROBOT_API_KEY` environment variable, or add it as a provider attribute:
+
+```hcl
+provider "uptimerobot" {
+  api_key = "xxx"
+}
+```
+
+Add a monitor resource:
+
+```hcl
+resource "uptimerobot_monitor" "my_monitor" {
+  url           = "http://example.com"
+  type          = "http"
+  friendly_name = "Example"
+}
+```
+
+... where `type` is one of [MonitorTypeNames][].
+
+[MonitorTypeNames]: https://github.com/SpamapS/uptimerobot/blob/b95e7aed2bfe79e8eb6ea231a491a1303212bbc7/uptimerobot.go#L55-L64


### PR DESCRIPTION
Hey @SpamapS :wave: 

Thanks for this provider. I wanted to give it a roll and since this is the first time I'm using a community Terraform provider, I've tried to document its usage here.

This gets me half of the way there, but I'm currently running into a blocker where `CreateMonitor` doesn't succeed:

```hcl
resource "uptimerobot_monitor" "my_monitor" {
  url           = "http://example.com"
  type          = "http"
  friendly_name = "Example"
}
```

```
TF_LOG=TRACE UPTIMEROBOT_API_KEY="xxx" terraform apply

uptimerobot_monitor.my_monitor: Creating...
  friendly_name: "" => "Example"
  type:          "" => "http"
  url:           "" => "http://example.com"
2018-09-22T16:29:40.222+0100 [DEBUG] plugin.terraform-provider-uptimerobot: 2018/09/22 16:29:40 [TRACE] Sending req to https://api.uptimerobot.com/v2/newMonitor
2018-09-22T16:29:40.606+0100 [DEBUG] plugin.terraform-provider-uptimerobot: 2018/09/22 16:29:40 [DEBUG] Stat = fail
2018-09-22T16:29:40.607+0100 [DEBUG] plugin.terraform-provider-uptimerobot: 2018/09/22 16:29:40 [TRACE] resp = {fail {0 <nil>}}
2018-09-22T16:29:40.607+0100 [DEBUG] plugin.terraform-provider-uptimerobot: 2018/09/22 16:29:40 [DEBUG] error during changeMonitor = Server reports request not ok!
```

Am I missing a step?

Closes #1.